### PR TITLE
Don't allow selecting text in cell

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -127,6 +127,13 @@ $cell-background: #182026;
       caret-color: transparent;
       border: none;
 
+      -webkit-touch-callout: none;
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+
       &:focus {
         outline: none;
       }


### PR DESCRIPTION
This was causing some weird behavior where the text would be selected in mobile when tapping on a cell that contained a value